### PR TITLE
WIP-slideshow-Picasa-Url

### DIFF
--- a/classes/SlideshowPluginPostType.php
+++ b/classes/SlideshowPluginPostType.php
@@ -239,7 +239,7 @@ class SlideshowPluginPostType
 		// XTEC ************ AFEGIT - get slides from picasa
 		// 2014.10.22 @jmeler
 		echo '<hr><p style="color:green; font-weight:bold">Si voleu mostrar més de 10 diapositives us recomanem carregar-les des d\'un àlbum extern:</p>
-		<strong>Picasa</strong> (adreça <a target="_blank" href="https://sites.google.com/a/xtec.cat/ajudaxtecblocs/insercio-de-continguts/carrusel-d-imatges">RSS</a>):
+		<strong>Picasa</strong> (URL o adreça <a target="_blank" href="https://sites.google.com/a/xtec.cat/ajudaxtecblocs/insercio-de-continguts/carrusel-d-imatges">RSS</a>):
 		<input type="text" name="picasa_album" value='.get_post_meta( $post->ID, "picasa_album", true ).'><br>
 		<br>
 		<strong>Google+ Fotos</strong> (adreça web):<br>


### PR DESCRIPTION
Carrusels Picassa també amb adreça URL de l'album. Per fer les proves cal accededir a wp-admin --> Carrusels i crear un nou carrusel Picasa. Aquest carrusel ha de funcionar tant amb la URL del RSS, com amb la URL de l'album. (Trello #1056)
URL album  --> https://picasaweb.google.com/114701668556234742860/BrusselLes
URL RSS --> https://picasaweb.google.com/data/feed/base/user/114701668556234742860/albumid/6048492321171379969?alt=rss&kind=photo&hl=ca
